### PR TITLE
Feature/option to add mastermix to inplate

### DIFF
--- a/lib/MasterMixMaker_.go
+++ b/lib/MasterMixMaker_.go
@@ -17,11 +17,27 @@ import (
 
 // Input parameters for this protocol (data)
 
+// This specifies the multiplier of each of the Volumes for each component to add
+// e.g. if "glucose" vol is "1ul" and Reactionspermastermix == 3 then 3ul glucose is added to mastermix
+
+// Specify volumes per component in same order of components.
+// The actual volume added will be multiplied by the number of Reactionspermastermix
+
+// List of names of components to be added
+// These will be used to look up components by name in the factory.
+// If not found in the factory, new components will be created using dna_mix as a template
+// If empty, the the ComponentIn will be returned as an output
+
+// If using the inventory system, select whether to check inventory for parts so missing parts may be ordered.
+
 // If set to true the mix will be prepared on the next available position on the input plate
+// Otherwise the mastermix will be added to OutPlate
 
 // Data which is returned from this protocol, and data types
 
 // Physical Inputs to this protocol with types
+
+// if OptimisePlateUsage is set to false this will be the plate type which the mastermix will be transferred to.
 
 // Physical outputs from this protocol with types
 
@@ -207,12 +223,12 @@ func init() {
 			Desc: "Make a general mastermix comprising of a list of components, list of volumes\nand specifying the number of reactions required\n",
 			Path: "src/github.com/antha-lang/elements/starter/MakeMasterMix_PCR/MasterMixMaker.an",
 			Params: []component.ParamDesc{
-				{Name: "CheckPartsInInventory", Desc: "", Kind: "Parameters"},
-				{Name: "ComponentVolumesperReaction", Desc: "", Kind: "Parameters"},
-				{Name: "Components", Desc: "", Kind: "Parameters"},
-				{Name: "OptimisePlateUsage", Desc: "If set to true the mix will be prepared on the next available position on the input plate\n", Kind: "Parameters"},
-				{Name: "OutPlate", Desc: "", Kind: "Inputs"},
-				{Name: "Reactionspermastermix", Desc: "", Kind: "Parameters"},
+				{Name: "CheckPartsInInventory", Desc: "If using the inventory system, select whether to check inventory for parts so missing parts may be ordered.\n", Kind: "Parameters"},
+				{Name: "ComponentVolumesperReaction", Desc: "Specify volumes per component in same order of components.\nThe actual volume added will be multiplied by the number of Reactionspermastermix\n", Kind: "Parameters"},
+				{Name: "Components", Desc: "List of names of components to be added\nThese will be used to look up components by name in the factory.\nIf not found in the factory, new components will be created using dna_mix as a template\nIf empty, the the ComponentIn will be returned as an output\n", Kind: "Parameters"},
+				{Name: "OptimisePlateUsage", Desc: "If set to true the mix will be prepared on the next available position on the input plate\nOtherwise the mastermix will be added to OutPlate\n", Kind: "Parameters"},
+				{Name: "OutPlate", Desc: "if OptimisePlateUsage is set to false this will be the plate type which the mastermix will be transferred to.\n", Kind: "Inputs"},
+				{Name: "Reactionspermastermix", Desc: "This specifies the multiplier of each of the Volumes for each component to add\ne.g. if \"glucose\" vol is \"1ul\" and Reactionspermastermix == 3 then 3ul glucose is added to mastermix\n", Kind: "Parameters"},
 				{Name: "Mastermix", Desc: "", Kind: "Outputs"},
 				{Name: "PlateWithMastermix", Desc: "", Kind: "Outputs"},
 				{Name: "Status", Desc: "", Kind: "Data"},

--- a/starter/MakeMasterMix_PCR/MasterMixMaker.an
+++ b/starter/MakeMasterMix_PCR/MasterMixMaker.an
@@ -7,6 +7,8 @@ import (
 	"github.com/antha-lang/antha/antha/anthalib/mixer"
 	"github.com/antha-lang/antha/microArch/factory"
 	"github.com/antha-lang/antha/antha/anthalib/setup"
+	"github.com/antha-lang/antha/antha/anthalib/wutil"
+	
 )
 
 
@@ -16,6 +18,9 @@ Parameters (
 	ComponentVolumesperReaction []Volume
 	Components []string
 	CheckPartsInInventory bool
+	
+	// If set to true the mix will be prepared on the next available position on the input plate
+	OptimisePlateUsage bool
 )
 
 // Data which is returned from this protocol, and data types
@@ -47,6 +52,21 @@ Setup {
 // for every input
 Steps {
 	
+	// make up 20% extra to ensure reagents are sufficient accounting for dead volumes and evaporation
+	extraReactions := float64(Reactionspermastermix) * 1.2
+	
+	roundedReactions, err := wutil.RoundDown(extraReactions)
+	
+	if err != nil {
+		Errorf(err.Error())
+	}
+	
+	roundedUpReactions := roundedReactions + 1
+	
+	if roundedUpReactions <= Reactionspermastermix  {
+		Reactionspermastermix = Reactionspermastermix + 1
+	}
+	
 	
 	var mastermix *wtype.LHComponent
 	
@@ -64,7 +84,7 @@ Steps {
 				lhComponents = append(lhComponents,factory.GetComponentByType(component))
 			}else {
 				// if component not in factory use dna as default component type
-				defaultcomponent := factory.GetComponentByType("dna")
+				defaultcomponent := factory.GetComponentByType("dna_mix")
 				defaultcomponent.CName = component
 				lhComponents = append(lhComponents,defaultcomponent)
 			}
@@ -80,7 +100,7 @@ Steps {
 		lhComponents[0] = Handle(setup.PlatePrep(lhComponents[0]))
 
 		// a setup step
-    	lhComponents[0] = Handle(setup.MarkForSetup(lhComponents[0]))
+    		lhComponents[0] = Handle(setup.MarkForSetup(lhComponents[0]))
 		}
 		
 		// now make mastermix
@@ -89,6 +109,7 @@ Steps {
 		
 		
 		for k, component := range lhComponents { 	
+			
 			if k == len(lhComponents)-1{
 				component.Type = wtype.LTPostMix 
 			}
@@ -102,7 +123,11 @@ Steps {
 		
 		
 		}
-	mastermix = MixInto(OutPlate, "",  eachmastermix...)
+	if OptimisePlateUsage {
+		mastermix = Mix(eachmastermix...)
+	}else {
+		mastermix = MixInto(OutPlate, "",  eachmastermix...)
+	}
 	
 	Mastermix = mastermix
 	PlateWithMastermix = OutPlate

--- a/starter/MakeMasterMix_PCR/MasterMixMaker.an
+++ b/starter/MakeMasterMix_PCR/MasterMixMaker.an
@@ -14,14 +14,28 @@ import (
 
 // Input parameters for this protocol (data)
 Parameters (
+	
+	// This specifies the multiplier of each of the Volumes for each component to add
+	// e.g. if "glucose" vol is "1ul" and Reactionspermastermix == 3 then 3ul glucose is added to mastermix
 	Reactionspermastermix int
+	
+	// Specify volumes per component in same order of components.
+ 	// The actual volume added will be multiplied by the number of Reactionspermastermix
 	ComponentVolumesperReaction []Volume
+	
+	// List of names of components to be added
+	// These will be used to look up components by name in the factory. 
+	// If not found in the factory, new components will be created using dna_mix as a template
+ 	// If empty, the the ComponentIn will be returned as an output
 	Components []string
+	
+	// If using the inventory system, select whether to check inventory for parts so missing parts may be ordered.
 	CheckPartsInInventory bool
 	
 	// If set to true the mix will be prepared on the next available position on the input plate
+	// Otherwise the mastermix will be added to OutPlate
 	OptimisePlateUsage bool
-)
+	)
 
 // Data which is returned from this protocol, and data types
 Data (
@@ -31,7 +45,7 @@ Data (
 
 // Physical Inputs to this protocol with types
 Inputs (
-
+	// if OptimisePlateUsage is set to false this will be the plate type which the mastermix will be transferred to.
 	OutPlate *wtype.LHPlate
 )
 


### PR DESCRIPTION
Adds a boolean input which when selected adds the mastermix to the next available space on the inplate rather than a separate plate, therefore allows better optimisation of deckspace.

contains #64 