### PR TITLE
Use correct LHComponent in mastermixmaker

### DIFF
--- a/lib/MasterMixMaker_.go
+++ b/lib/MasterMixMaker_.go
@@ -83,7 +83,8 @@ func _MasterMixMakerSteps(_ctx context.Context, _input *MasterMixMakerInput, _ou
 			lhComponents = append(lhComponents, factory.GetComponentByType(component))
 		} else {
 			// if component not in factory use dna as default component type
-			defaultcomponent := factory.GetComponentByType("dna_mix")
+			defaultcomponent := factory.GetComponentByType("dna_part")
+			defaultcomponent.Type = wtype.LTDNAMIX
 			defaultcomponent.CName = component
 			lhComponents = append(lhComponents, defaultcomponent)
 		}

--- a/starter/MakeMasterMix_PCR/MasterMixMaker.an
+++ b/starter/MakeMasterMix_PCR/MasterMixMaker.an
@@ -98,7 +98,8 @@ Steps {
 				lhComponents = append(lhComponents,factory.GetComponentByType(component))
 			}else {
 				// if component not in factory use dna as default component type
-				defaultcomponent := factory.GetComponentByType("dna_mix")
+				defaultcomponent := factory.GetComponentByType("dna_part")
+				defaultcomponent.Type = wtype.LTDNAMIX
 				defaultcomponent.CName = component
 				lhComponents = append(lhComponents,defaultcomponent)
 			}


### PR DESCRIPTION
Fixes issue that a non-existent component was being called from the factory resulting in a runtime error