### PR TITLE
Changing the returned variables in elements who depend on download.File

### DIFF
--- a/an/Liquid_handling/PipetteImage/AssemblePalette.an
+++ b/an/Liquid_handling/PipetteImage/AssemblePalette.an
@@ -85,7 +85,7 @@ func (rbscollection collection) Max()(rbs RBSdata) {
 // The core process for this protocol, with the steps to be performed
 // for every input
 Steps {
-	
+
 	var rbsstrengthdata []RBSdata =[]RBSdata{
 		RBSdata{wtype.MakeLinearDNASequence("rbs1","gggcgcgc"),0.0},
 		RBSdata{wtype.MakeLinearDNASequence("rbs2","gggcgcgc"),2.0},
@@ -101,7 +101,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}
@@ -113,10 +113,10 @@ Steps {
 	
 	
 	// make palette of colours from image
-	chosencolourpalette := image.MakeSmallPalleteFromImage(Imagefilename, PlateWithMasterMix,Rotate) 
+	chosencolourpalette := image.MakeSmallPalleteFromImage(Imagefilename, PlateWithMasterMix,Rotate)
 	
 	// make a map of colour to well coordinates
-	positiontocolourmap, _,_ := image.ImagetoPlatelayout(Imagefilename, PlateWithMasterMix, &chosencolourpalette, Rotate, AutoRotate) 
+	positiontocolourmap, _,_ := image.ImagetoPlatelayout(Imagefilename, PlateWithMasterMix, &chosencolourpalette, Rotate, AutoRotate)
 	
 	// remove duplicates
 	positiontocolourmap = image.RemoveDuplicatesValuesfromMap(positiontocolourmap)

--- a/an/Liquid_handling/PipetteImage/AssemblePalette_transform.an
+++ b/an/Liquid_handling/PipetteImage/AssemblePalette_transform.an
@@ -89,7 +89,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/MakePalette_OnebyOne.an
+++ b/an/Liquid_handling/PipetteImage/MakePalette_OnebyOne.an
@@ -65,7 +65,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/MakePalette_OnebyOne_RGB.an
+++ b/an/Liquid_handling/PipetteImage/MakePalette_OnebyOne_RGB.an
@@ -62,7 +62,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/MakePallete.an
+++ b/an/Liquid_handling/PipetteImage/MakePallete.an
@@ -64,7 +64,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/PipetteImage/PipetteImage/PipetteImage.an
+++ b/an/Liquid_handling/PipetteImage/PipetteImage/PipetteImage/PipetteImage.an
@@ -65,7 +65,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/PipetteImage/fromPalette/MakePalette_2.an
+++ b/an/Liquid_handling/PipetteImage/PipetteImage/fromPalette/MakePalette_2.an
@@ -68,7 +68,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/PipetteImage/fromPalette/PipetteImage_fromPalette.an
+++ b/an/Liquid_handling/PipetteImage/PipetteImage/fromPalette/PipetteImage_fromPalette.an
@@ -63,7 +63,7 @@ Steps {
 		
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/PipetteImage/grascale/PipetteImage_Gray.an
+++ b/an/Liquid_handling/PipetteImage/PipetteImage/grascale/PipetteImage_Gray.an
@@ -70,7 +70,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/PipetteImage_CMYK.an
+++ b/an/Liquid_handling/PipetteImage/PipetteImage_CMYK.an
@@ -56,7 +56,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/PipetteImage_CMYK_OneByOne.an
+++ b/an/Liquid_handling/PipetteImage/PipetteImage_CMYK_OneByOne.an
@@ -56,7 +56,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/PipetteImage_fromPalette_refactor.an
+++ b/an/Liquid_handling/PipetteImage/PipetteImage_fromPalette_refactor.an
@@ -63,7 +63,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/PipetteLivingimage.an
+++ b/an/Liquid_handling/PipetteImage/PipetteLivingimage.an
@@ -64,7 +64,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/PreProcessImage.an
+++ b/an/Liquid_handling/PipetteImage/PreProcessImage.an
@@ -53,7 +53,7 @@ Steps {
 	
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Liquid_handling/PipetteImage/TransformLivingPalette.an
+++ b/an/Liquid_handling/PipetteImage/TransformLivingPalette.an
@@ -112,7 +112,7 @@ Steps {
 
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Utility/AccuracyTest/AccuracyTest_Conc.an
+++ b/an/Utility/AccuracyTest/AccuracyTest_Conc.an
@@ -101,7 +101,7 @@ Steps {
 		
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Utility/AccuracyTest_2.an
+++ b/an/Utility/AccuracyTest_2.an
@@ -90,7 +90,7 @@ Steps {
 		
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/an/Utility/AccuracyTest_3.an
+++ b/an/Utility/AccuracyTest_3.an
@@ -103,7 +103,7 @@ Steps {
 		
 	// if image is from url, download
 	if UseURL {
-		err := download.File(URL, Imagefilename)
+		_, err := download.File(URL, Imagefilename)
 		if err != nil{
 			Errorf(err.Error())
 		}

--- a/lib/AccuracyTest_2_.go
+++ b/lib/AccuracyTest_2_.go
@@ -62,7 +62,7 @@ func _AccuracyTest_2Steps(_ctx context.Context, _input *AccuracyTest_2Input, _ou
 
 		// if image is from url, download
 		if _input.UseURL {
-			err := download.File(_input.URL, _input.Imagefilename)
+			_, err := download.File(_input.URL, _input.Imagefilename)
 			if err != nil {
 				execute.Errorf(_ctx, err.Error())
 			}

--- a/lib/AccuracyTest_3_.go
+++ b/lib/AccuracyTest_3_.go
@@ -77,7 +77,7 @@ func _AccuracyTest_3Steps(_ctx context.Context, _input *AccuracyTest_3Input, _ou
 
 		// if image is from url, download
 		if _input.UseURL {
-			err := download.File(_input.URL, _input.Imagefilename)
+			_, err := download.File(_input.URL, _input.Imagefilename)
 			if err != nil {
 				execute.Errorf(_ctx, err.Error())
 			}

--- a/lib/AccuracyTest_Concentration_.go
+++ b/lib/AccuracyTest_Concentration_.go
@@ -75,7 +75,7 @@ func _AccuracyTest_ConcentrationSteps(_ctx context.Context, _input *AccuracyTest
 
 		// if image is from url, download
 		if _input.UseURL {
-			err := download.File(_input.URL, _input.Imagefilename)
+			_, err := download.File(_input.URL, _input.Imagefilename)
 			if err != nil {
 				execute.Errorf(_ctx, err.Error())
 			}

--- a/lib/AssemblePalette_OneByOne_RGB_2_.go
+++ b/lib/AssemblePalette_OneByOne_RGB_2_.go
@@ -85,7 +85,7 @@ func _AssemblePalette_OneByOne_RGB_2Steps(_ctx context.Context, _input *Assemble
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/AssemblePalette_OneByOne_RGB_transform_2_.go
+++ b/lib/AssemblePalette_OneByOne_RGB_transform_2_.go
@@ -70,7 +70,7 @@ func _AssemblePalette_OneByOne_RGB_transform_2Steps(_ctx context.Context, _input
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/MakePalette_.go
+++ b/lib/MakePalette_.go
@@ -47,7 +47,7 @@ func _MakePaletteSteps(_ctx context.Context, _input *MakePaletteInput, _output *
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/MakePalette_2_.go
+++ b/lib/MakePalette_2_.go
@@ -47,7 +47,7 @@ func _MakePalette_2Steps(_ctx context.Context, _input *MakePalette_2Input, _outp
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/MakePalette_OneByOne_.go
+++ b/lib/MakePalette_OneByOne_.go
@@ -44,7 +44,7 @@ func _MakePalette_OneByOneSteps(_ctx context.Context, _input *MakePalette_OneByO
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/MakePalette_OneByOne_RGB_.go
+++ b/lib/MakePalette_OneByOne_RGB_.go
@@ -46,7 +46,7 @@ func _MakePalette_OneByOne_RGBSteps(_ctx context.Context, _input *MakePalette_On
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/PipetteImage_.go
+++ b/lib/PipetteImage_.go
@@ -45,7 +45,7 @@ func _PipetteImageSteps(_ctx context.Context, _input *PipetteImageInput, _output
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/PipetteImage_CMYK_.go
+++ b/lib/PipetteImage_CMYK_.go
@@ -42,7 +42,7 @@ func _PipetteImage_CMYKSteps(_ctx context.Context, _input *PipetteImage_CMYKInpu
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/PipetteImage_CMYK_OneByOne_.go
+++ b/lib/PipetteImage_CMYK_OneByOne_.go
@@ -42,7 +42,7 @@ func _PipetteImage_CMYK_OneByOneSteps(_ctx context.Context, _input *PipetteImage
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/PipetteImage_Gray_.go
+++ b/lib/PipetteImage_Gray_.go
@@ -45,7 +45,7 @@ func _PipetteImage_GraySteps(_ctx context.Context, _input *PipetteImage_GrayInpu
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/PipetteImage_fromPalette_.go
+++ b/lib/PipetteImage_fromPalette_.go
@@ -44,7 +44,7 @@ func _PipetteImage_fromPaletteSteps(_ctx context.Context, _input *PipetteImage_f
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/PipetteImage_fromPalette_refactor_.go
+++ b/lib/PipetteImage_fromPalette_refactor_.go
@@ -44,7 +44,7 @@ func _PipetteImage_fromPalette_refactorSteps(_ctx context.Context, _input *Pipet
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/PipetteImage_living_.go
+++ b/lib/PipetteImage_living_.go
@@ -43,7 +43,7 @@ func _PipetteImage_livingSteps(_ctx context.Context, _input *PipetteImage_living
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/PreProcessImage_.go
+++ b/lib/PreProcessImage_.go
@@ -38,7 +38,7 @@ func _PreProcessImageSteps(_ctx context.Context, _input *PreProcessImageInput, _
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/lib/TransformLivingPalette_.go
+++ b/lib/TransformLivingPalette_.go
@@ -93,7 +93,7 @@ func _TransformLivingPaletteSteps(_ctx context.Context, _input *TransformLivingP
 
 	// if image is from url, download
 	if _input.UseURL {
-		err := download.File(_input.URL, _input.Imagefilename)
+		_, err := download.File(_input.URL, _input.Imagefilename)
 		if err != nil {
 			execute.Errorf(_ctx, err.Error())
 		}

--- a/workflows/examples/AccuracyTest/parameters.yml
+++ b/workflows/examples/AccuracyTest/parameters.yml
@@ -3,8 +3,6 @@ Parameters:
     DXORJMP: JMP
     Diluent: water
     Imagefilename: star.png
-    UseURL: true
-    URL: https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Gold_Star.svg/1000px-Gold_Star.svg.png
     LHPolicy: PostMix
     NumberofBlanks: 1
     NumberofReplicates: 5
@@ -21,4 +19,6 @@ Parameters:
     TestSols:
     - tartrazine
     TotalVolume: 100ul
+    URL: https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Gold_Star.svg/1000px-Gold_Star.svg.png
     UseLiquidPolicyForTestSolutions: true
+    UseURL: true

--- a/workflows/examples/Make_Colour_palette/parameters.yml
+++ b/workflows/examples/Make_Colour_palette/parameters.yml
@@ -8,5 +8,5 @@ Parameters:
     OutPlate: greiner384_riser
     Rotate: false
     VolumeForFullcolour: 150ul
-    Yellow: Yellow_ink
     White: whiteFabricDye
+    Yellow: Yellow_ink


### PR DESCRIPTION
This will break the elements, another update from origin/ImageSync will make them work again.

The change is necessary because we are changing the download.File to use the wtype.File type instead of filenames.