### PR TITLE
add stock concentration override options for SerialDilution_conc_multi

### DIFF
--- a/an/Liquid_handling/SerialDilution/SerialDilution_Conc_multi/SerialDilution_Conc_multi.an
+++ b/an/Liquid_handling/SerialDilution/SerialDilution_Conc_multi/SerialDilution_Conc_multi.an
@@ -12,18 +12,22 @@ import (
 // Input parameters for this protocol (data)
 Parameters (
 	
-	// specify a starting total volume per dilution, not accounting for the volume lost by using that component to make the next dilution
-	// a "default" may be specified which applies to all values with no explicit value set in this map
+	// Specify a starting total volume per dilution, not accounting for the volume lost by using that component to make the next dilution.
+	// A "default" may be specified which applies to all values with no explicit value set in this map.
 	StartVolumeperDilution 	map[string]Volume 
 	
-	// specify target concentrations to make for each solution
-	// a "default" may be specified which applies to all values with no explicit value set in this map
-	TargetConcentrations  	map[string][]Concentration// specify target concentrations for 
+	// Specify target concentrations to make for each solution.
+	// A "default" may be specified which applies to all values with no explicit value set in this map.
+	TargetConcentrations  	map[string][]Concentration
 	
-	// optionally choose whether to aliqout the serial dilutions by row instead of the default by column
+	// Optional parameter to override the solution concentration.
+	// A "default" may be specified which applies to all values with no explicit value set in this map.
+	OverrideStockConcentrations map[string]Concentration
+	
+	// Optionally choose whether to aliqout the serial dilutions by row instead of the default by column.
 	ByRow 					bool 
 	
-	// optionally start after a specified well position if wells are allready used in the plate
+	// Optionally start after a specified well position if wells are allready used in the plate.
 	WellsAlreadyUsed			int 
 )
 
@@ -36,13 +40,13 @@ Data (
 // Physical Inputs to this protocol with types
 Inputs (
 	
-	// starting solutions. The names of the solutions will be used to set concentrations and starting volumes in the other parameters
+	// Starting solutions. The names of the solutions will be used to set concentrations and starting volumes in the other parameters
 	SolutionsWithConcentrations []*wtype.LHComponent 
 	
-	// Use the same diluent for all component dilutions
+	// Use the same diluent for all component dilutions.
 	Diluent 					*wtype.LHComponent
 	
-	// use the same outplate for all dilutions
+	// Use the same outplate for all dilutions.
 	OutPlate 					*wtype.LHPlate
 )
 
@@ -91,10 +95,14 @@ Steps {
 		}
 		
 		var solConc Concentration
-		if solution.HasConcentration(){
+		if conc, found := OverrideStockConcentrations[solution.CName];found{
+			solConc = conc
+		}else if conc, found := OverrideStockConcentrations["default"];found{
+			solConc = conc
+		}else if solution.HasConcentration(){
 			solConc = solution.Concentration()
 		}else{
-			Errorf("no concentration found for %s, please set this. ",solution.CName)
+			Errorf("no Stock Concentration found for %s, please set this. ",solution.CName)
 		}
 		
 		// run SerialDilution_ForConcentration element

--- a/lib/SerialDilution_Conc_multi_.go
+++ b/lib/SerialDilution_Conc_multi_.go
@@ -14,26 +14,28 @@ import (
 
 // Input parameters for this protocol (data)
 
-// specify a starting total volume per dilution, not accounting for the volume lost by using that component to make the next dilution
-// a "default" may be specified which applies to all values with no explicit value set in this map
+// Specify a starting total volume per dilution, not accounting for the volume lost by using that component to make the next dilution.
+// A "default" may be specified which applies to all values with no explicit value set in this map.
 
-// specify target concentrations to make for each solution
-// a "default" may be specified which applies to all values with no explicit value set in this map
-// specify target concentrations for
+// Specify target concentrations to make for each solution.
+// A "default" may be specified which applies to all values with no explicit value set in this map.
 
-// optionally choose whether to aliqout the serial dilutions by row instead of the default by column
+// Optional parameter to override the solution concentration.
+// A "default" may be specified which applies to all values with no explicit value set in this map.
 
-// optionally start after a specified well position if wells are allready used in the plate
+// Optionally choose whether to aliqout the serial dilutions by row instead of the default by column.
+
+// Optionally start after a specified well position if wells are allready used in the plate.
 
 // Data which is returned from this protocol, and data types
 
 // Physical Inputs to this protocol with types
 
-// starting solutions. The names of the solutions will be used to set concentrations and starting volumes in the other parameters
+// Starting solutions. The names of the solutions will be used to set concentrations and starting volumes in the other parameters
 
-// Use the same diluent for all component dilutions
+// Use the same diluent for all component dilutions.
 
-// use the same outplate for all dilutions
+// Use the same outplate for all dilutions.
 
 // Physical outputs from this protocol with types
 
@@ -76,10 +78,14 @@ func _SerialDilution_Conc_multiSteps(_ctx context.Context, _input *SerialDilutio
 		}
 
 		var solConc wunit.Concentration
-		if solution.HasConcentration() {
+		if conc, found := _input.OverrideStockConcentrations[solution.CName]; found {
+			solConc = conc
+		} else if conc, found := _input.OverrideStockConcentrations["default"]; found {
+			solConc = conc
+		} else if solution.HasConcentration() {
 			solConc = solution.Concentration()
 		} else {
-			execute.Errorf(_ctx, "no concentration found for %s, please set this. ", solution.CName)
+			execute.Errorf(_ctx, "no Stock Concentration found for %s, please set this. ", solution.CName)
 		}
 
 		// run SerialDilution_ForConcentration element
@@ -171,6 +177,7 @@ type SerialDilution_Conc_multiInput struct {
 	ByRow                       bool
 	Diluent                     *wtype.LHComponent
 	OutPlate                    *wtype.LHPlate
+	OverrideStockConcentrations map[string]wunit.Concentration
 	SolutionsWithConcentrations []*wtype.LHComponent
 	StartVolumeperDilution      map[string]wunit.Volume
 	TargetConcentrations        map[string][]wunit.Concentration
@@ -200,13 +207,14 @@ func init() {
 			Desc: "Protocol to make a series of serial dilution sets. Each set targeting a series of specified setpoint concentrations.\nA series of input solutions are specified which must have the stock concentration specified, e.g. by NewLHComponents.\nA common diluent will be used for all.\n",
 			Path: "src/github.com/antha-lang/elements/an/Liquid_handling/SerialDilution/SerialDilution_Conc_multi/SerialDilution_Conc_multi.an",
 			Params: []component.ParamDesc{
-				{Name: "ByRow", Desc: "optionally choose whether to aliqout the serial dilutions by row instead of the default by column\n", Kind: "Parameters"},
-				{Name: "Diluent", Desc: "Use the same diluent for all component dilutions\n", Kind: "Inputs"},
-				{Name: "OutPlate", Desc: "use the same outplate for all dilutions\n", Kind: "Inputs"},
-				{Name: "SolutionsWithConcentrations", Desc: "starting solutions. The names of the solutions will be used to set concentrations and starting volumes in the other parameters\n", Kind: "Inputs"},
-				{Name: "StartVolumeperDilution", Desc: "specify a starting total volume per dilution, not accounting for the volume lost by using that component to make the next dilution\na \"default\" may be specified which applies to all values with no explicit value set in this map\n", Kind: "Parameters"},
-				{Name: "TargetConcentrations", Desc: "specify target concentrations to make for each solution\na \"default\" may be specified which applies to all values with no explicit value set in this map\n\nspecify target concentrations for\n", Kind: "Parameters"},
-				{Name: "WellsAlreadyUsed", Desc: "optionally start after a specified well position if wells are allready used in the plate\n", Kind: "Parameters"},
+				{Name: "ByRow", Desc: "Optionally choose whether to aliqout the serial dilutions by row instead of the default by column.\n", Kind: "Parameters"},
+				{Name: "Diluent", Desc: "Use the same diluent for all component dilutions.\n", Kind: "Inputs"},
+				{Name: "OutPlate", Desc: "Use the same outplate for all dilutions.\n", Kind: "Inputs"},
+				{Name: "OverrideStockConcentrations", Desc: "Optional parameter to override the solution concentration.\nA \"default\" may be specified which applies to all values with no explicit value set in this map.\n", Kind: "Parameters"},
+				{Name: "SolutionsWithConcentrations", Desc: "Starting solutions. The names of the solutions will be used to set concentrations and starting volumes in the other parameters\n", Kind: "Inputs"},
+				{Name: "StartVolumeperDilution", Desc: "Specify a starting total volume per dilution, not accounting for the volume lost by using that component to make the next dilution.\nA \"default\" may be specified which applies to all values with no explicit value set in this map.\n", Kind: "Parameters"},
+				{Name: "TargetConcentrations", Desc: "Specify target concentrations to make for each solution.\nA \"default\" may be specified which applies to all values with no explicit value set in this map.\n", Kind: "Parameters"},
+				{Name: "WellsAlreadyUsed", Desc: "Optionally start after a specified well position if wells are allready used in the plate.\n", Kind: "Parameters"},
 				{Name: "AllDilutions", Desc: "", Kind: "Outputs"},
 				{Name: "DilutionsByComponent", Desc: "", Kind: "Outputs"},
 				{Name: "WellsUsedPostRun", Desc: "", Kind: "Data"},


### PR DESCRIPTION
For convenience the option is added to set stock concentrations to input solutions in the case that they do not have one set already. 