### PR TITLE
Upgrade to Aliquot element

### DIFF
--- a/defaults/aliquot.bundle.json
+++ b/defaults/aliquot.bundle.json
@@ -1,7 +1,9 @@
 {
   "Parameters": {
     "AliquotParams": {
-      "ChangeSolutionName": "",
+      "ByRow": false,
+      "ChangeSolutionName": "Sausages",
+      "NumberOfReplicaPlates": 3,
       "NumberofAliquots": 8,
       "OutPlate": "pcrplate_with_cooler",
       "PreMix": false,

--- a/defaults/aliquot.bundle.json
+++ b/defaults/aliquot.bundle.json
@@ -2,7 +2,7 @@
   "Parameters": {
     "AliquotParams": {
       "ByRow": false,
-      "ChangeSolutionName": "Sausages",
+      "ChangeSolutionName": "",
       "NumberOfReplicaPlates": 3,
       "NumberofAliquots": 8,
       "OutPlate": "pcrplate_with_cooler",

--- a/lib/Aliquot_.go
+++ b/lib/Aliquot_.go
@@ -25,13 +25,19 @@ import (
 
 // This parameter states the number of aliquots that will be made from the input Solution.
 
+// This parameter states whether the aliquots should be made by row or column.
+
+// This parameter sets the number of replica plates to perform aliquots to.
+
 // This parameter is an optional field. If the solution to be aliquoted has components that may sink to the bottom of the solution then select this option for the solution to be premixed prior to transfer.
 
 // This parameter is an optional field. If you want to change the name of the input Solution for traceability then do so. If not the default name will be given as the chosen input Solution LHComponent name.
 
-// This parameter is an optional field. If set to true then the aliquots will be transferred to a specific named plate such that if two instances of this element are run in parallel the aliquots from both will be put on the same output plate rather than two separate output plates.
+// This parameter is an optional field. It states the number of wells that have already been used in the output plate and will start making aliquots from this position onwards.
 
 // Data which is returned from this protocol, and data types
+
+// This data output is a count of how many wells have been used in the output plate.
 
 // Physical Inputs to this protocol with types
 
@@ -77,29 +83,36 @@ func _AliquotSteps(_ctx context.Context, _input *AliquotInput, _output *AliquotO
 		_input.Solution.CName = _input.ChangeSolutionName
 	}
 
+	// This code allows the user to specify how the aliquots should be made, by row or by column.
+	allwellpositions := _input.OutPlate.AllWellPositions(_input.ByRow)
+
 	aliquots := make([]*wtype.LHComponent, 0)
 
-	for i := 0; i < _input.NumberofAliquots; i++ {
-		if _input.Solution.TypeName() == "dna" {
-			_input.Solution.Type = wtype.LTDoNotMix
-		}
-		aliquotSample := mixer.Sample(_input.Solution, _input.VolumePerAliquot)
+	// This loop allows the user to specify the number of replica plates of aliquots they want.
+	for platenumber := 1; platenumber < (_input.NumberOfReplicaPlates + 1); platenumber++ {
+		var counter int = _input.WellsAlreadyUsed
 
-		// the MixInto command is used instead of Mix to specify the plate
-		// MixInto allows you to specify the exact plate to MixInto (i.e. rather than just a plate type. e.g. barcode 123214234)
-		// the three input fields to the MixInto command represent
-		// 1. the plate
-		// 2. well location as a  string e.g. "A1" (in this case leaving it blank "" will leave the well location up to the scheduler),
-		// 3. the sample or array of samples to be mixed
-		var aliquot *wtype.LHComponent
-		if _input.OptimisePlateUsage {
-			aliquot = execute.MixNamed(_ctx, _input.OutPlate.Type, "", "AliquotPlate", aliquotSample)
-		} else {
-			aliquot = execute.MixInto(_ctx, _input.OutPlate, "", aliquotSample)
+		// This loop cycles through the number of aliquots required
+		for i := 0; i < _input.NumberofAliquots; i++ {
+
+			// This statement changes the liquid handling policy if the soultion being aliquoted is DNA to avoid cross contamination.
+			if _input.Solution.TypeName() == "dna" {
+				_input.Solution.Type = wtype.LTDoNotMix
+			}
+			aliquotSample := mixer.Sample(_input.Solution, _input.VolumePerAliquot)
+
+			var aliquot *wtype.LHComponent
+
+			// The MixTo command here cycles through the well positions of the chosen plate type and plate number for each aliquot.
+			aliquot = execute.MixTo(_ctx, _input.OutPlate.Type, allwellpositions[counter], platenumber, aliquotSample)
+
+			if aliquot != nil {
+				aliquots = append(aliquots, aliquot)
+			}
+			// Counter is increased by 1 each cycle of the loop to keep track of the wells used.
+			counter++
 		}
-		if aliquot != nil {
-			aliquots = append(aliquots, aliquot)
-		}
+		_output.WellsUsed = counter
 	}
 	_output.Aliquots = aliquots
 }
@@ -164,22 +177,26 @@ type AliquotElement struct {
 }
 
 type AliquotInput struct {
-	ChangeSolutionName string
-	NumberofAliquots   int
-	OptimisePlateUsage bool
-	OutPlate           *wtype.LHPlate
-	PreMix             bool
-	Solution           *wtype.LHComponent
-	SolutionVolume     wunit.Volume
-	VolumePerAliquot   wunit.Volume
+	ByRow                 bool
+	ChangeSolutionName    string
+	NumberOfReplicaPlates int
+	NumberofAliquots      int
+	OutPlate              *wtype.LHPlate
+	PreMix                bool
+	Solution              *wtype.LHComponent
+	SolutionVolume        wunit.Volume
+	VolumePerAliquot      wunit.Volume
+	WellsAlreadyUsed      int
 }
 
 type AliquotOutput struct {
-	Aliquots []*wtype.LHComponent
+	Aliquots  []*wtype.LHComponent
+	WellsUsed int
 }
 
 type AliquotSOutput struct {
 	Data struct {
+		WellsUsed int
 	}
 	Outputs struct {
 		Aliquots []*wtype.LHComponent
@@ -193,15 +210,18 @@ func init() {
 			Desc: "The Aliquot element will transfer a defined liquid at defined volumes a specified number of times into a chosen plate type.\nThe user has the option to premix the solution to be aliquoted if the input solution tends to sediment or separate when left to stand\n(e.g. a suspension of cells in media) or has recently been thawed. Upstream elements that produce solutions as outputs can be wired\ninto the Solution parameter of this element for aliquoting. If the solution already exists in your lab or has been made manually but a definition for this solution does\nnot exist in the Antha library then the AddNewLHComponent element can be used to define this solution with the output from the\nelement wired into the Solution parameter of this element.\n",
 			Path: "src/github.com/antha-lang/elements/starter/Aliquot/Aliquot.an",
 			Params: []component.ParamDesc{
+				{Name: "ByRow", Desc: "This parameter states whether the aliquots should be made by row or column.\n", Kind: "Parameters"},
 				{Name: "ChangeSolutionName", Desc: "This parameter is an optional field. If you want to change the name of the input Solution for traceability then do so. If not the default name will be given as the chosen input Solution LHComponent name.\n", Kind: "Parameters"},
+				{Name: "NumberOfReplicaPlates", Desc: "This parameter sets the number of replica plates to perform aliquots to.\n", Kind: "Parameters"},
 				{Name: "NumberofAliquots", Desc: "This parameter states the number of aliquots that will be made from the input Solution.\n", Kind: "Parameters"},
-				{Name: "OptimisePlateUsage", Desc: "This parameter is an optional field. If set to true then the aliquots will be transferred to a specific named plate such that if two instances of this element are run in parallel the aliquots from both will be put on the same output plate rather than two separate output plates.\n", Kind: "Parameters"},
 				{Name: "OutPlate", Desc: "This parameter alows you to specify the type of plate you are aliquoting your Solution into. Choose from one of the available plate options from the Antha plate library.\n", Kind: "Inputs"},
 				{Name: "PreMix", Desc: "This parameter is an optional field. If the solution to be aliquoted has components that may sink to the bottom of the solution then select this option for the solution to be premixed prior to transfer.\n", Kind: "Parameters"},
 				{Name: "Solution", Desc: "This Physical input will have associated properties to determine how the liquid should be handled, e.g. is your Solution water or is it Glycerol. If your physical liquid does not exist in the Antha LHComponent library then create a new one on the fly with the AddNewLHComponent element and wire the output into this input. Alternatively wire a solution made by another element into this input to be alliquoted.\n", Kind: "Inputs"},
 				{Name: "SolutionVolume", Desc: "This parameter represents the volume of solution that you have in the lab available to be aliquoted. It does not represent the total volume to be aliquoted or the volume of liquid that will be used.\n", Kind: "Parameters"},
 				{Name: "VolumePerAliquot", Desc: "This parameter dictates the final volume each aliquot will have.\n", Kind: "Parameters"},
+				{Name: "WellsAlreadyUsed", Desc: "This parameter is an optional field. It states the number of wells that have already been used in the output plate and will start making aliquots from this position onwards.\n", Kind: "Parameters"},
 				{Name: "Aliquots", Desc: "This is a list of the resulting aliquots that have been made by the element.\n", Kind: "Outputs"},
+				{Name: "WellsUsed", Desc: "This data output is a count of how many wells have been used in the output plate.\n", Kind: "Data"},
 			},
 		},
 	}); err != nil {

--- a/starter/Aliquot/Aliquot.an
+++ b/starter/Aliquot/Aliquot.an
@@ -20,16 +20,23 @@ Parameters (
 	VolumePerAliquot Volume
 	// This parameter states the number of aliquots that will be made from the input Solution.
 	NumberofAliquots int
+	// This parameter states whether the aliquots should be made by row or column.
+	ByRow bool
+	// This parameter sets the number of replica plates to perform aliquots to.
+	NumberOfReplicaPlates int
 	// This parameter is an optional field. If the solution to be aliquoted has components that may sink to the bottom of the solution then select this option for the solution to be premixed prior to transfer.
 	PreMix bool
 	// This parameter is an optional field. If you want to change the name of the input Solution for traceability then do so. If not the default name will be given as the chosen input Solution LHComponent name.
 	ChangeSolutionName string
-	// This parameter is an optional field. If set to true then the aliquots will be transferred to a specific named plate such that if two instances of this element are run in parallel the aliquots from both will be put on the same output plate rather than two separate output plates.
-	OptimisePlateUsage bool
+	// This parameter is an optional field. It states the number of wells that have already been used in the output plate and will start making aliquots from this position onwards.
+	WellsAlreadyUsed int
 )
 
 // Data which is returned from this protocol, and data types
-Data ()
+Data (
+	// This data output is a count of how many wells have been used in the output plate.
+	WellsUsed int
+)
 
 // Physical Inputs to this protocol with types
 Inputs (
@@ -79,29 +86,36 @@ Steps {
 		Solution.CName = ChangeSolutionName
 	}
 
+	// This code allows the user to specify how the aliquots should be made, by row or by column.	
+	allwellpositions := OutPlate.AllWellPositions(ByRow)
+
 	aliquots := make([]*LHComponent, 0)
 
+	// This loop allows the user to specify the number of replica plates of aliquots they want.
+	for platenumber := 1; platenumber < (NumberOfReplicaPlates + 1); platenumber++{
+		var counter int = WellsAlreadyUsed
+	
+	// This loop cycles through the number of aliquots required	
 	for i := 0; i < NumberofAliquots; i++ {
+		
+		// This statement changes the liquid handling policy if the soultion being aliquoted is DNA to avoid cross contamination.
 		if Solution.TypeName() == "dna" {
 			Solution.Type = wtype.LTDoNotMix
 		}
 		aliquotSample := mixer.Sample(Solution, VolumePerAliquot)
+		
+		var aliquot *LHComponent	
+			
+		// The MixTo command here cycles through the well positions of the chosen plate type and plate number for each aliquot.
+		aliquot = MixTo(OutPlate.Type, allwellpositions[counter], platenumber, aliquotSample)
 
-		// the MixInto command is used instead of Mix to specify the plate
-		// MixInto allows you to specify the exact plate to MixInto (i.e. rather than just a plate type. e.g. barcode 123214234)
-		// the three input fields to the MixInto command represent
-		// 1. the plate
-		// 2. well location as a  string e.g. "A1" (in this case leaving it blank "" will leave the well location up to the scheduler),
-		// 3. the sample or array of samples to be mixed
-		var aliquot *LHComponent
-		if OptimisePlateUsage {
-			aliquot = MixNamed(OutPlate.Type, "", "AliquotPlate", aliquotSample)
-		} else {
-			aliquot = MixInto(OutPlate, "", aliquotSample)
-		}
 		if aliquot != nil {
 			aliquots = append(aliquots, aliquot)
 		}
+		// Counter is increased by 1 each cycle of the loop to keep track of the wells used.
+		counter++
+	}
+		WellsUsed = counter
 	}
 	Aliquots = aliquots
 }

--- a/starter/Aliquot/Aliquot.an
+++ b/starter/Aliquot/Aliquot.an
@@ -22,13 +22,13 @@ Parameters (
 	NumberofAliquots int
 	// This parameter states whether the aliquots should be made by row or column.
 	ByRow bool
-	// This parameter sets the number of replica plates to perform aliquots to.
+	// This parameter sets the number of replica plates to perform aliquots to. Default number of plates is 1.
 	NumberOfReplicaPlates int
 	// This parameter is an optional field. If the solution to be aliquoted has components that may sink to the bottom of the solution then select this option for the solution to be premixed prior to transfer.
 	PreMix bool
 	// This parameter is an optional field. If you want to change the name of the input Solution for traceability then do so. If not the default name will be given as the chosen input Solution LHComponent name.
 	ChangeSolutionName string
-	// This parameter is an optional field. It states the number of wells that have already been used in the output plate and will start making aliquots from this position onwards.
+	// This parameter is an optional field. It states the number of wells that have already been used in the output plate and will start making aliquots from this position onwards. If there is more than one replica plate all plates would have the same number of wells already used.
 	WellsAlreadyUsed int
 )
 
@@ -91,6 +91,11 @@ Steps {
 
 	aliquots := make([]*LHComponent, 0)
 
+	// This code checks to make sure the number of replica plates is greater than 0.
+	if NumberOfReplicaPlates < 1 {
+	Errorf("Number of replica plates must be greater than 0")
+	}
+
 	// This loop allows the user to specify the number of replica plates of aliquots they want.
 	for platenumber := 1; platenumber < (NumberOfReplicaPlates + 1); platenumber++{
 		var counter int = WellsAlreadyUsed
@@ -107,6 +112,12 @@ Steps {
 		var aliquot *LHComponent	
 			
 		// The MixTo command here cycles through the well positions of the chosen plate type and plate number for each aliquot.
+		// the MixTo command is used instead of Mix to specify the plate type (e.g. "greiner384" or "pcrplate_skirted")
+		// the four input fields to the MixTo command represent
+		// 1. the platetype as a string: commonly the input to the antha element will actually be an LHPlate rather than a string so the type field can be accessed with OutPlate.Type
+		// 2. well location as a  string e.g. "A1" (in this instance determined by a counter and the plate type or leaving it blank "" will leave the well location up to the scheduler),
+		// 3. the plate number as an integer, starting from 1 (not zero)
+		// 4. the sample or array of samples to be mixed; in the case of an array you'd normally feed this in as samples...
 		aliquot = MixTo(OutPlate.Type, allwellpositions[counter], platenumber, aliquotSample)
 
 		if aliquot != nil {


### PR DESCRIPTION
added by row ability and replica plating ability. Needed to change MixNamed to MixTo for replica plating but can change back to MixNamed and just add a number to the end of the plate name each replica if you prefer. Therefore i removed optimise plate usage from this element because that scrambles all the aliquots out of order (which might not always be bad but could be if you want a defined order)